### PR TITLE
refactor: rename StackSUSU branding to HearthCircle

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,7 +1,7 @@
 [project]
-name = "stacksusu"
-description = "StackSUSU - Decentralized Rotating Savings (Ajo/Susu) on Stacks"
-authors = ["StackSUSU Team"]
+name = "hearthcircle"
+description = "HearthCircle - Decentralized Rotating Savings (Ajo/Susu) on Stacks"
+authors = ["HearthCircle Team"]
 telemetry = true
 cache_dir = "./.cache"
 boot_contracts = ["pox-4"]

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,4 +1,4 @@
-# StackSUSU V7 Mainnet Deployment Guide
+# HearthCircle V7 Mainnet Deployment Guide
 
 ## 🆕 V7 Features
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
-# savings-circle-net
+# HearthCircle
 
-![Build Status](https://img.shields.io/badge/build-passing-brightgreen)
-![License](https://img.shields.io/badge/license-MIT-blue)
-![Version](https://img.shields.io/badge/version-1.0.0-orange)
+HearthCircle is a community-first savings circle platform built on Stacks. It modernizes rotating savings groups with transparent rules, trusted payouts, and member reputation.
 
-## Overview
+## Why HearthCircle
 
-Savings Circle Net digitizes traditional Rotating Savings and Credit Associations (ROSCAs). It empowers communities to manage collective savings pools securely and transparently using modern web technologies.
-
-## Key Features
-
-- **Group Management**: Easy tools for creating and managing savings circles.\n- **Automated Payouts**: Scheduled and secure fund distribution.\n- **Trust Scoring**: Reputation systems for circle members.\n- **Multi-Currency**: Support for diverse fiat and crypto assets.
+- **Circle management** for creating, joining, and running shared savings pools.
+- **Automated payouts** with predictable schedules and transparent records.
+- **Trust signals** via reputation, participation history, and badges.
+- **Wallet-ready** flows for Stacks-native deposits and withdrawals.
 
 ## Getting Started
 
@@ -19,18 +16,42 @@ Savings Circle Net digitizes traditional Rotating Savings and Credit Association
 - Node.js v18+
 - npm v9+
 
-### Installation
+### Install
 
 ```bash
-git clone https://github.com/harobedjosh-alt/savings-circle-net.git
+git clone https://github.com/floxxih/savings-circle-net.git
 cd savings-circle-net
 npm install
 ```
 
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+### Contracts
+
+```bash
+clarinet check
+```
+
+## Project Layout
+
+```
+savings-circle-net/
+├── contracts/     # Clarity contracts
+├── frontend/      # React + Vite web app
+├── docs/          # Architecture and guides
+└── README.md      # Project documentation
+```
+
 ## Contributing
 
-We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+See `CONTRIBUTING.md` for local setup, testing, and contribution guidelines.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+MIT

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -13,7 +13,7 @@
 
 ```bash
 # Clone the repository
-git clone https://github.com/harobedjosh-alt/savings-circle-net.git
+git clone https://github.com/floxxih/savings-circle-net.git
 cd savings-circle-net
 
 # Install dependencies
@@ -29,7 +29,7 @@ npm test
 ## Project Structure
 
 ```
-stacksusu/
+hearthcircle/
 ├── contracts/          # Clarity smart contracts
 ├── frontend/          # React frontend application
 │   ├── src/
@@ -298,4 +298,4 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for contribution guidelines.
 
 - Create an issue on GitHub
 - Join our Discord community
-- Email: dev-team@stacksusu.com
+- Email: dev-team@hearthcircle.com

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide covers testing practices for the StackSUSU application, including unit tests, integration tests, and contract tests.
+This guide covers testing practices for the HearthCircle application, including unit tests, integration tests, and contract tests.
 
 ## Testing Stack
 
@@ -60,7 +60,7 @@ beforeAll(async () => {
   simnet = await initSimnet();
 }, 60000);
 
-describe("StackSUSU Core Contract", () => {
+describe("HearthCircle Core Contract", () => {
   it("should create a circle", async () => {
     const accounts = simnet.getAccounts();
     const deployer = accounts.get("deployer")!;

--- a/frontend/CONTRIBUTING.md
+++ b/frontend/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# StackSUSU Frontend Contributing Guidelines
+# HearthCircle Frontend Contributing Guidelines
 
-Thank you for your interest in contributing to StackSUSU!
+Thank you for your interest in contributing to HearthCircle!
 
 ## Development Setup
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,4 +1,4 @@
-# StackSUSU Frontend
+# HearthCircle Frontend
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0-blue.svg)](https://www.typescriptlang.org/)
@@ -7,7 +7,7 @@
 [![Stacks](https://img.shields.io/badge/Stacks-Mainnet-5546FF.svg)](https://www.stacks.co/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 
-A modern React frontend for the StackSUSU decentralized savings circle platform built on Stacks blockchain.
+A modern React frontend for the HearthCircle decentralized savings circle platform built on Stacks blockchain.
 
 ## Tech Stack
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint';
 import { defineConfig, globalIgnores } from 'eslint/config';
 
 /**
- * ESLint configuration for StackSUSU frontend
+ * ESLint configuration for HearthCircle frontend
  * @see https://eslint.org/docs/latest/use/configure/
  */
 export default defineConfig([

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,19 +8,19 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     
     <!-- SEO Meta Tags -->
-    <title>StackSUSU - Decentralized Savings Circles on Stacks</title>
+    <title>HearthCircle - Decentralized Savings Circles on Stacks</title>
     <meta name="description" content="Join rotating savings circles powered by Stacks blockchain. Save together, earn trust-based NFT badges, and build financial community." />
     <meta name="keywords" content="stacks, blockchain, defi, savings, susu, rotating credit, chit fund" />
     
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="StackSUSU - Decentralized Savings Circles" />
+    <meta property="og:title" content="HearthCircle - Decentralized Savings Circles" />
     <meta property="og:description" content="Join rotating savings circles powered by Stacks blockchain." />
     <meta property="og:url" content="https://stacksusu.com" />
     
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="StackSUSU - Decentralized Savings Circles" />
+    <meta name="twitter:title" content="HearthCircle - Decentralized Savings Circles" />
     <meta name="twitter:description" content="Join rotating savings circles powered by Stacks blockchain." />
     
     <!-- Theme Color -->
@@ -34,7 +34,7 @@
     <noscript>
       <div style="padding: 2rem; text-align: center;">
         <h1>JavaScript Required</h1>
-        <p>StackSUSU requires JavaScript to run. Please enable JavaScript in your browser.</p>
+        <p>HearthCircle requires JavaScript to run. Please enable JavaScript in your browser.</p>
       </div>
     </noscript>
     <div id="root"></div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@stacksusu/frontend",
-  "description": "StackSUSU decentralized savings circle frontend",
+  "name": "@hearthcircle/frontend",
+  "description": "HearthCircle decentralized savings circle frontend",
   "private": true,
   "version": "1.0.0",
   "type": "module",
@@ -12,7 +12,7 @@
     "susu",
     "react"
   ],
-  "author": "StackSUSU Team",
+  "author": "HearthCircle Team",
   "license": "MIT",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -2,7 +2,7 @@
  * Breadcrumb Navigation Component
  * 
  * Provides hierarchical navigation with customizable separators
- * and support for dynamic routes in the StackSUSU application.
+ * and support for dynamic routes in the HearthCircle application.
  * 
  * @module components/Breadcrumb
  */

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -81,7 +81,7 @@ function Navbar() {
       <div className="navbar__container">
         <Link to="/" className="navbar__brand">
           <span className="navbar__brand-icon">🔄</span>
-          <span className="navbar__brand-text">StackSUSU</span>
+          <span className="navbar__brand-text">HearthCircle</span>
         </Link>
 
         {/* Desktop Navigation */}

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -150,7 +150,7 @@ const circleStatusMap: Record<CircleStatus, StatusType> = {
 };
 
 /**
- * Circle status badge with StackSUSU-specific labels
+ * Circle status badge with HearthCircle-specific labels
  */
 export function CircleStatusBadge({
   status,

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -1,7 +1,7 @@
 /**
- * StackSUSU Configuration Constants
+ * HearthCircle Configuration Constants
  * 
- * Centralized configuration for the StackSUSU application.
+ * Centralized configuration for the HearthCircle application.
  * All constants are grouped by category and use `as const` for type safety.
  * 
  * @module config/constants
@@ -11,7 +11,7 @@
 // App Configuration
 // ============================================================
 
-export const APP_NAME = 'StackSUSU';
+export const APP_NAME = 'HearthCircle';
 export const APP_VERSION = '1.0.0';
 export const APP_DESCRIPTION = 'Decentralized savings circles on Stacks';
 

--- a/frontend/src/constants/contracts.ts
+++ b/frontend/src/constants/contracts.ts
@@ -1,5 +1,5 @@
 /**
- * StackSUSU Smart Contract Constants
+ * HearthCircle Smart Contract Constants
  * Maps to values in the Clarity v7 contracts
  */
 

--- a/frontend/src/context/index.ts
+++ b/frontend/src/context/index.ts
@@ -1,5 +1,5 @@
 /**
- * React Context Providers and Hooks for StackSUSU
+ * React Context Providers and Hooks for HearthCircle
  * 
  * This module exports all context providers for application-wide state
  * management. Context providers enable shared state across component trees

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,5 +1,5 @@
 /**
- * Custom React hooks for StackSUSU
+ * Custom React hooks for HearthCircle
  * 
  * @module hooks
  */

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,7 +1,7 @@
 /**
  * Application Constants
  * 
- * Centralized constants for the StackSUSU application.
+ * Centralized constants for the HearthCircle application.
  * Includes configuration values, UI strings, and limits.
  * 
  * @module lib/constants

--- a/frontend/src/lib/contracts.ts
+++ b/frontend/src/lib/contracts.ts
@@ -1,8 +1,8 @@
 /**
- * StackSUSU Contract Definitions
+ * HearthCircle Contract Definitions
  * 
  * Contains contract addresses, function names, and constants
- * for interacting with the StackSUSU smart contracts.
+ * for interacting with the HearthCircle smart contracts.
  * 
  * @module lib/contracts
  */
@@ -11,7 +11,7 @@
 // Contract Addresses
 // ============================================================
 
-/** StackSUSU contract addresses on mainnet */
+/** HearthCircle contract addresses on mainnet */
 export const CONTRACTS = {
   /** Core circle management contract */
   CORE: 'SP3FKNEZ86RG5RT7SZ5FBRGH85FZNG94ZH1MCGG6N.stacksusu-core-v4',

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,5 @@
 /**
- * StackSUSU Application Entry Point
+ * HearthCircle Application Entry Point
  * 
  * Initializes the React application with StrictMode for development
  * checks and renders the App component to the DOM.

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -90,7 +90,7 @@ const Home = memo(function Home() {
         <div className="home__hero-content">
           <h1 className="home__hero-title">Save Together, Grow Together</h1>
           <p className="home__hero-description">
-            StackSUSU brings the traditional rotating savings circle to the blockchain.
+            HearthCircle brings the traditional rotating savings circle to the blockchain.
             Join trusted groups, contribute regularly, and take turns receiving the pool.
           </p>
           <div className="home__hero-buttons">
@@ -151,7 +151,7 @@ const Home = memo(function Home() {
 
       {/* Features */}
       <section className="home__features">
-        <h2 className="home__section-title">Why Choose StackSUSU?</h2>
+        <h2 className="home__section-title">Why Choose HearthCircle?</h2>
         <div className="home__feature-grid">
           {FEATURES.map((feature, index) => {
             const Icon = feature.icon;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 /**
- * API Service for StackSUSU
+ * API Service for HearthCircle
  * 
  * Provides HTTP client for:
  * - Stacks blockchain API interactions

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -1,7 +1,7 @@
 /**
  * Service Layer Exports
  * 
- * Provides API and blockchain interaction services for the StackSUSU app.
+ * Provides API and blockchain interaction services for the HearthCircle app.
  * 
  * @module services
  * 

--- a/frontend/src/services/nft.ts
+++ b/frontend/src/services/nft.ts
@@ -340,10 +340,10 @@ export function formatNFTDisplay(token: NFTToken): {
 } {
   const meta = token.metadata ?? null;
   return {
-    title: `StackSUSU Slot #${token.tokenId}`,
+    title: `HearthCircle Slot #${token.tokenId}`,
     description: meta 
       ? `Slot ${meta['slotNumber']} in Circle ${meta.circleId}`
-      : 'StackSUSU Membership Slot',
+      : 'HearthCircle Membership Slot',
     image: generateNFTImage(meta),
     attributes: [
       { trait: 'Circle ID', value: meta?.circleId?.toString() || 'Unknown' },

--- a/frontend/src/services/stacks.ts
+++ b/frontend/src/services/stacks.ts
@@ -235,7 +235,7 @@ export async function getContractInterface(contractId: string): Promise<unknown>
   return fetchApi(`/v2/contracts/interface/${address}/${name}`);
 }
 
-// StackSUSU specific API calls
+// HearthCircle specific API calls
 export async function getCircleCount(): Promise<number> {
   const result = await callContractReadOnly(
     CONTRACTS.CORE,

--- a/frontend/src/services/wallet.ts
+++ b/frontend/src/services/wallet.ts
@@ -2,7 +2,7 @@
  * Wallet Service
  * 
  * Handles Hiro Wallet connection and transaction signing for
- * interacting with StackSUSU smart contracts.
+ * interacting with HearthCircle smart contracts.
  * 
  * @module services/wallet
  */
@@ -100,7 +100,7 @@ export async function connectWallet(): Promise<WalletConnection> {
     return new Promise((resolve, reject) => {
       showConnect({
         appDetails: {
-          name: 'StackSUSU',
+          name: 'HearthCircle',
           icon: window.location.origin + '/logo.png',
         },
         onFinish: (data) => {

--- a/frontend/src/styles/animations.css
+++ b/frontend/src/styles/animations.css
@@ -1,5 +1,5 @@
 /**
- * Animations - StackSUSU Design System
+ * Animations - HearthCircle Design System
  * Reusable keyframes and animation utilities
  */
 

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1,5 +1,5 @@
 /**
- * StackSUSU Design System
+ * HearthCircle Design System
  * Main stylesheet entry point
  * 
  * This file imports all design system modules:

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,5 +1,5 @@
 /**
- * Design Tokens - StackSUSU Design System
+ * Design Tokens - HearthCircle Design System
  * Core design tokens for consistent styling across the app
  */
 

--- a/frontend/src/styles/utilities.css
+++ b/frontend/src/styles/utilities.css
@@ -1,5 +1,5 @@
 /**
- * Utility Classes - StackSUSU Design System
+ * Utility Classes - HearthCircle Design System
  * Reusable utility classes for common patterns
  */
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,5 @@
 /**
- * Type definitions for StackSUSU
+ * Type definitions for HearthCircle
  * 
  * @module types
  */

--- a/frontend/src/types/stacks-transactions.d.ts
+++ b/frontend/src/types/stacks-transactions.d.ts
@@ -1,6 +1,6 @@
 /**
  * Type declarations for @stacks/transactions
- * Minimal types for what we use in StackSUSU
+ * Minimal types for what we use in HearthCircle
  */
 
 declare module '@stacks/transactions' {

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -1,7 +1,7 @@
 /**
  * Analytics Utility
  * 
- * Analytics tracking system for the StackSUSU application.
+ * Analytics tracking system for the HearthCircle application.
  * Tracks user interactions, page views, and custom events
  * for product insights and optimization.
  * 

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,5 +1,5 @@
 /**
- * API utility functions for StackSUSU
+ * API utility functions for HearthCircle
  * Handles Stacks blockchain API interactions
  */
 

--- a/frontend/src/utils/cache.ts
+++ b/frontend/src/utils/cache.ts
@@ -1,7 +1,7 @@
 /**
  * Cache Utility
  * 
- * Client-side caching system for the StackSUSU application.
+ * Client-side caching system for the HearthCircle application.
  * Provides in-memory caching with TTL support and localStorage persistence.
  * 
  * @module utils/cache

--- a/frontend/src/utils/crypto.ts
+++ b/frontend/src/utils/crypto.ts
@@ -2,7 +2,7 @@
  * Crypto Utilities
  * 
  * Cryptographic helper functions for hashing, encoding, and
- * blockchain-related operations in the StackSUSU application.
+ * blockchain-related operations in the HearthCircle application.
  * 
  * @module utils/crypto
  */

--- a/frontend/src/utils/debug.ts
+++ b/frontend/src/utils/debug.ts
@@ -1,7 +1,7 @@
 /**
  * Debug Utilities
  * 
- * Development and debugging helpers for the StackSUSU application.
+ * Development and debugging helpers for the HearthCircle application.
  * Provides debugging tools, React DevTools integration, and
  * development-time utilities.
  * 

--- a/frontend/src/utils/emergency.ts
+++ b/frontend/src/utils/emergency.ts
@@ -1,5 +1,5 @@
 /**
- * Emergency system utility functions for StackSUSU
+ * Emergency system utility functions for HearthCircle
  * Handles emergency pauses, withdrawals, and circuit breaker functionality
  */
 

--- a/frontend/src/utils/error.ts
+++ b/frontend/src/utils/error.ts
@@ -1,7 +1,7 @@
 /**
  * Error Handling Utility
  * 
- * Centralized error handling system for the StackSUSU application.
+ * Centralized error handling system for the HearthCircle application.
  * Provides error classification, user-friendly messages, and error tracking.
  * 
  * @module utils/error

--- a/frontend/src/utils/escrow.ts
+++ b/frontend/src/utils/escrow.ts
@@ -1,5 +1,5 @@
 /**
- * Escrow system utility functions for StackSUSU
+ * Escrow system utility functions for HearthCircle
  */
 
 import { BLOCK_TIMES, ESCROW_CONFIG } from '../constants/contracts';

--- a/frontend/src/utils/governance.ts
+++ b/frontend/src/utils/governance.ts
@@ -1,5 +1,5 @@
 /**
- * Governance-related utility functions for StackSUSU
+ * Governance-related utility functions for HearthCircle
  */
 
 import { BLOCK_TIMES } from '../constants/contracts';

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 /**
- * General Utility Functions for StackSUSU
+ * General Utility Functions for HearthCircle
  * 
  * Common helper functions for formatting, validation, and conversions.
  * 

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,7 +1,7 @@
 /**
  * Utility Functions
  * 
- * Centralized utilities for the StackSUSU application.
+ * Centralized utilities for the HearthCircle application.
  * Provides formatting, validation, and helper functions for
  * blockchain operations, UI rendering, and data manipulation.
  * 
@@ -283,4 +283,3 @@ export * from './storage';
 
 // Crypto utilities
 export * from './crypto';
-

--- a/frontend/src/utils/logger.ts
+++ b/frontend/src/utils/logger.ts
@@ -1,7 +1,7 @@
 /**
  * Logger Utility
  * 
- * Centralized logging system for the StackSUSU application.
+ * Centralized logging system for the HearthCircle application.
  * Provides structured logging with different log levels and
  * formatting for development and production environments.
  * 

--- a/frontend/src/utils/member.ts
+++ b/frontend/src/utils/member.ts
@@ -1,5 +1,5 @@
 /**
- * Member-related utility functions for StackSUSU
+ * Member-related utility functions for HearthCircle
  */
 
 import { MEMBER_STATUS, REPUTATION_TIERS } from '../constants/contracts';

--- a/frontend/src/utils/mock-data.ts
+++ b/frontend/src/utils/mock-data.ts
@@ -1,7 +1,7 @@
 /**
  * Mock Data Generators
  * 
- * Comprehensive mock data generators for testing the StackSUSU application.
+ * Comprehensive mock data generators for testing the HearthCircle application.
  * Provides realistic test data for all data types in the system.
  * 
  * @module utils/mock-data

--- a/frontend/src/utils/nft.ts
+++ b/frontend/src/utils/nft.ts
@@ -1,5 +1,5 @@
 /**
- * NFT-related utility functions for StackSUSU
+ * NFT-related utility functions for HearthCircle
  */
 
 import { microStxToStx } from './stx';
@@ -103,7 +103,7 @@ export function formatNFTPrice(microStx: number): string {
  */
 export function generateNFTMetadataUri(nft: NFTMetadata): string {
   const metadata = {
-    name: `StackSUSU Completion #${nft.id}`,
+    name: `HearthCircle Completion #${nft.id}`,
     description: `Proof of completing savings circle "${nft.circleName}"`,
     image: getNFTImageUrl(nft.tier, nft.circleId),
     attributes: [

--- a/frontend/src/utils/performance.ts
+++ b/frontend/src/utils/performance.ts
@@ -1,7 +1,7 @@
 /**
  * Performance Monitoring Utility
  * 
- * Performance tracking and monitoring system for the StackSUSU application.
+ * Performance tracking and monitoring system for the HearthCircle application.
  * Provides Core Web Vitals tracking, custom performance metrics, and
  * performance reporting.
  * 

--- a/frontend/src/utils/referral.ts
+++ b/frontend/src/utils/referral.ts
@@ -1,5 +1,5 @@
 /**
- * Referral system utility functions for StackSUSU
+ * Referral system utility functions for HearthCircle
  */
 
 import { REFERRAL_CONFIG } from '../constants/contracts';

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -231,7 +231,7 @@ export function createNamespacedStorage(namespace: string) {
 }
 
 /**
- * Create a storage instance for the StackSUSU app
+ * Create a storage instance for the HearthCircle app
  */
 export const stacksusuStorage = createNamespacedStorage('stacksusu');
 

--- a/frontend/src/utils/test-utils.ts
+++ b/frontend/src/utils/test-utils.ts
@@ -1,7 +1,7 @@
 /**
  * Testing Utilities
  * 
- * Testing helpers and utilities for the StackSUSU application.
+ * Testing helpers and utilities for the HearthCircle application.
  * Provides mocking utilities, test data generators, and testing
  * helpers for Vitest.
  * 

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,5 +1,5 @@
 /**
- * StackSUSU Frontend Type Declarations
+ * HearthCircle Frontend Type Declarations
  * 
  * Global type declarations for Vite environment and custom modules.
  */

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 
 /**
- * Vite configuration for StackSUSU frontend
+ * Vite configuration for HearthCircle frontend
  * @see https://vite.dev/config/
  */
 export default defineConfig({

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "stacksusu",
+  "name": "hearthcircle",
   "version": "1.0.0",
-  "description": "StackSUSU - Decentralized rotating savings circles on Stacks blockchain",
+  "description": "HearthCircle - Decentralized rotating savings circles on Stacks blockchain",
   "type": "module",
   "private": true,
   "scripts": {
@@ -23,7 +23,7 @@
     "prepare": "husky install || true",
     "update-deps": "npm update && cd frontend && npm update"
   },
-  "author": "StackSUSU Team",
+  "author": "HearthCircle Team",
   "license": "MIT",
   "dependencies": {
     "@hirosystems/clarinet-sdk": "^3.8.1",


### PR DESCRIPTION
## Summary
- refresh branding to HearthCircle across docs and frontend copy
- update metadata, config labels, and setup instructions to match the new name

## Testing
- not run (branding-only changes)
